### PR TITLE
Clear cache at set timeout

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "extends": "./node_modules/@kaliber/eslint-plugin/.eslintrc",
   "rules": {
     "@kaliber/no-relative-parent-import": "off",
-    "import/no-unresolved": "off"
+    "import/no-unresolved": "off",
+    "no-undef": "off"
   },
   "settings": {
       "@kaliber/eslint-plugin/lib/absolute-path-resolver-plugin": null

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "sideEffects": false,
   "type": "module",
   "scripts": {
-    "test": "node --test"
+    "test": "node --expose-gc --test"
   },
   "publishConfig": {
     "access": "public"

--- a/src/cache.js
+++ b/src/cache.js
@@ -91,7 +91,7 @@ export function createCache({ allowReturnExpiredValue, expirationTime }) {
   }
 }
 
-/** @arg {*} x @returns {x is Promise<infer T>} */
+/** @arg {*} x @returns {x is Promise<any>} */
 function isPromiseLike(x) {
   return typeof x?.then === 'function'
 }

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,9 +1,18 @@
 /** @import { CacheParams, Cache } from './types.ts' */
 
+const dayInMilliseconds = 24 * 60 * 60 * 1000
+const maxTimeoutValue = 0x7FFFFFFF // 32 bit signed integer
+
 /** @arg {CacheParams} params */
 export function createCache({ allowReturnExpiredValue, expirationTime }) {
   /** @type {Record<string, any>} */
   const cache = {}
+
+  if (expirationTime > maxTimeoutValue)
+    throw new Error(`Expiration time too large, max value: ${maxTimeoutValue}`)
+
+  if (allowReturnExpiredValue && expirationTime >= dayInMilliseconds)
+    console.trace('It is not possible to return expired items when expiration time is larger than one day')
 
   /** @type {Cache} */
   return function getCachedValue({ cacheKey, getValue }) {
@@ -12,23 +21,77 @@ export function createCache({ allowReturnExpiredValue, expirationTime }) {
     const cachedItem = cache[safeCacheKey]
 
     const isValid = cachedItem && cachedItem.validUntil >= now
-    if (isValid) return cachedItem.value
+    if (isValid && allowReturnExpiredValue && cachedItem.isPending && cachedItem.previousValue !== undefined)
+      return cachedItem.previousValue
+
+    if (isValid)
+      return cachedItem.value
 
     const callbackValue = getValue()
+    const isPromise = isPromiseLike(callbackValue)
 
-    const newCacheItem = { value: callbackValue, validUntil: now + expirationTime }
+    if (cachedItem && cachedItem.timeoutId)
+      clearTimeout(cachedItem.timeoutId)
+
+    const hardExpirationTime = (
+      allowReturnExpiredValue && expirationTime >= dayInMilliseconds ? expirationTime :
+      allowReturnExpiredValue ? Math.min(dayInMilliseconds, expirationTime * 10) :
+      expirationTime
+    )
+
+    const newCacheItem = {
+      value: callbackValue,
+      validUntil: now + expirationTime,
+      isPending: isPromise,
+      previousValue: isPromise ? cachedItem?.value : undefined,
+      storedUntil: now + hardExpirationTime,
+      timeoutId: deleteFromCacheTimeout(hardExpirationTime),
+    }
     cache[safeCacheKey] = newCacheItem
 
-    if (hasCatchProperty(callbackValue)) callbackValue.catch(() => {
-      if (cache[safeCacheKey] !== newCacheItem) return
-      cache[safeCacheKey] = cachedItem
-    })
+    if (isPromise)
+      callbackValue
+        .then(
+          _ => {
+            newCacheItem.isPending = false
+            newCacheItem.previousValue = undefined
+          },
+          () => {
+            clearTimeout(newCacheItem.timeoutId)
+            if (cache[safeCacheKey] !== newCacheItem)
+              return
+
+            if (!cachedItem)
+              return deleteFromCache()
+
+            const newHardExpirationTime = cachedItem.storedUntil - Date.now()
+            const hasExpired = newHardExpirationTime <= 0
+            if (hasExpired)
+              return deleteFromCache()
+
+            // the timeout was cleared before we fetched the value, so we need to create a new one
+            cachedItem.timeoutId = deleteFromCacheTimeout(newHardExpirationTime)
+
+            cache[safeCacheKey] = cachedItem
+          }
+        )
 
     return (cachedItem && allowReturnExpiredValue) ? cachedItem.value : newCacheItem.value
+
+    /** @arg {number} milliseconds */
+    function deleteFromCacheTimeout(milliseconds) {
+      const timeout = setTimeout(deleteFromCache, milliseconds)
+      timeout.unref?.()
+      return timeout
+    }
+
+    function deleteFromCache() {
+      delete cache[safeCacheKey]
+    }
   }
 }
 
-/** @arg {*} x @returns {x is { catch(f: (e: any) => void): any }} */
-function hasCatchProperty(x) {
-  return Boolean(x && x.catch)
+/** @arg {*} x @returns {x is Promise<infer T>} */
+function isPromiseLike(x) {
+  return typeof x?.then === 'function'
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,2 @@
-type Catchable<T> = T & { catch(callback: () => void): any }
 export type CacheParams = { allowReturnExpiredValue: boolean, expirationTime: number }
-export type Cache = <T>(props: { cacheKey: string | Array<any>, getValue: () => T | Catchable<T> }) => T
+export type Cache = <T>(props: { cacheKey: string | Array<any>, getValue: () => T }) => T

--- a/tests/createCache.test.js
+++ b/tests/createCache.test.js
@@ -64,7 +64,6 @@ describe('createCache with expiredValues disabled', () => {
     } catch (e) {
       // ignore error
     }
-
     expect(rejectedCallback).toHaveBeenCalledTimes(1)
 
     const result2 = await cache({ cacheKey, getValue: promiseCallback })
@@ -128,9 +127,257 @@ describe('createCache with expiredValues enabled', () => {
     const result2 = cache({ cacheKey, getValue: dontCallCallback })
     expect(dontCallCallback).toHaveBeenCalledTimes(0)
     expect(await result1).toEqual(expectedOutput)
-    await expect(result2).rejects.toEqual('this promise is rejected')
+    expect(await result2).toEqual(expectedOutput)
     const result3 = await cache({ cacheKey, getValue: rejectedCallback })
     expect(result3).toEqual(expectedOutput)
+  })
+})
+
+describe('createCache memory management', () => {
+  it('releases expired items from memory', async () => {
+    if (typeof global.gc !== 'function')
+      throw new Error('This test requires the --expose-gc flag to run. (e.g., node --expose-gc test.js)')
+
+    const cache = createCache({ allowReturnExpiredValue: false, expirationTime: 50 })
+    const cacheKey = 'releaseMemoryTest'
+
+    // 1. Create an object and wrap it in a WeakRef so we can monitor it without preventing it from being garbage collected.
+    /** @type {any} */
+    let largeObject = { hugeData: 'iAmHuge' }
+    const ref = new WeakRef(largeObject)
+
+    // 2. Put it in the cache
+    cache({ cacheKey, getValue: () => largeObject })
+
+    // 3. Destroy our local reference. Now, ONLY the cache is holding onto this object.
+    largeObject = null
+
+    // 4. Force GC. The object shouldn't be cleared yet because the cache still holds it.
+    global.gc()
+    expect(ref.deref() !== undefined).toBe(true)
+
+    // 5. Wait for the cache expiration time to pass
+    await timeout(75)
+
+    // 6. Force GC again. If the cache properly deleted its internal reference, the largeObject should now be swept away.
+    global.gc()
+
+    // 7. Verify the object has actually been released from memory
+    expect(ref.deref()).toBe(undefined)
+  })
+
+  it('returns stale data if requested before the hard expiration limit', t => {
+    t.mock.timers.enable()
+    const cache = createCache({ allowReturnExpiredValue: true, expirationTime: 10 })
+    const cacheKey = 'staleTest'
+
+    cache({ cacheKey, getValue: () => 'original data' })
+
+    t.mock.timers.tick(50)
+
+    const result = cache({ cacheKey, getValue: () => 'new data' })
+    expect(result).toBe('original data')
+  })
+
+  it('hard expires and completely purges the item if left untouched past the limit', t => {
+    t.mock.timers.enable()
+    const cache = createCache({ allowReturnExpiredValue: true, expirationTime: 10 })
+    const cacheKey = 'purgeTest'
+
+    cache({ cacheKey, getValue: () => 'original data' })
+
+    t.mock.timers.tick(101)
+
+    const result = cache({ cacheKey, getValue: () => 'new data' })
+    expect(result).toBe('new data')
+  })
+
+  it('does not delete subsequent valid entries when an earlier promise rejects', async t => {
+    t.mock.timers.enable()
+
+    const cache = createCache({ allowReturnExpiredValue: false, expirationTime: 50 })
+    const cacheKey = 'clearPurgeForFailedPromisesTest'
+
+    // 1. Cache a failing promise
+    await cache({ cacheKey, getValue: () => Promise.reject(new Error('Fetch failed')) })
+      .catch(() => {}) // ignore error here, we just want to know the promise is resolved
+
+    // 2. Move time forward so the next cache call does not have the same expiration
+    t.mock.timers.tick(25)
+
+    // 3. Cache a successful value
+    cache({ cacheKey, getValue: () => 'successful data' })
+
+    // 4. Move past 50ms (cache time of the failing promise)
+    t.mock.timers.tick(26)
+
+    // 5. Failing promise should not have triggered a purge of the cache
+    const result = cache({ cacheKey, getValue: () => 'should not be called' })
+
+    expect(result).toBe('successful data')
+  })
+
+  it('clears previous timeouts when refreshing stale data to prevent premature deletion', t => {
+    t.mock.timers.enable()
+
+    const cache = createCache({ allowReturnExpiredValue: true, expirationTime: 50 })
+    const cacheKey = 'raceConditionKey'
+
+    cache({ cacheKey, getValue: () => 'data v1' })
+
+    // The items is expired but not removed yet.
+    t.mock.timers.tick(100)
+
+    // Even though it has expired, it will return the old value
+    const result2 = cache({ cacheKey, getValue: () => 'data v2' })
+    expect(result2).toBe('data v1')
+
+    // The item has been removed
+    t.mock.timers.tick(401)
+
+    const result4 = cache({ cacheKey, getValue: () => 'data v3' })
+
+    // If the timeout has been handled correctly, we will get the cached data
+    expect(result4).toBe('data v2')
+  })
+
+  it('prevents memory leaks by re-applying timeouts when a background refresh fails', async t => {
+    t.mock.timers.enable()
+
+    const cache = createCache({ allowReturnExpiredValue: true, expirationTime: 50 })
+    const cacheKey = 'leakTestKey'
+
+    await cache({ cacheKey, getValue: () => Promise.resolve('original data') })
+
+    // The item is now stale.
+    t.mock.timers.tick(100)
+
+    // We intentionally make this background refresh fail.
+    const rejectedPromise = Promise.reject(new Error('Background fetch failed'))
+    cache({ cacheKey, getValue: () => rejectedPromise })
+
+    // Wait for the rejection to process and trigger your .catch() block
+    try { await rejectedPromise } catch (e) {}
+
+    // If the timeout wasn't restarted in the .catch() block, the item is stuck in memory forever.
+    t.mock.timers.tick(500)
+
+    const result3 = await cache({ cacheKey, getValue: () => Promise.resolve('fresh data') })
+
+    expect(result3).toBe('fresh data')
+  })
+
+  it('does not restore the stale item if it hard-expired while the background fetch was pending', async t => {
+    t.mock.timers.enable()
+
+    const cache = createCache({ allowReturnExpiredValue: true, expirationTime: 50 })
+    const cacheKey = 'expireDuringFetchKey'
+
+    cache({ cacheKey, getValue: () => 'original data' })
+
+    t.mock.timers.tick(100)
+
+    /** @type {(reason?: any) => void} */
+    let rejectPromise
+    const pendingPromise = new Promise((_, reject) => { rejectPromise = reject })
+
+    const result2 = cache({ cacheKey, getValue: () => pendingPromise })
+    expect(result2).toBe('original data')
+
+    t.mock.timers.tick(401)
+
+    // @ts-ignore
+    rejectPromise(new Error('Delayed failure'))
+
+    try { await pendingPromise } catch (e) {}
+
+    // The cache should be completely empty because the stale item was correctly discarded.
+    const result3 = cache({ cacheKey, getValue: () => 'fresh data' })
+
+    expect(result3).toBe('fresh data')
+  })
+
+  it('does not leak memory if getValue throws synchronously during a refresh', t => {
+    t.mock.timers.enable()
+
+    const cache = createCache({ allowReturnExpiredValue: true, expirationTime: 50 })
+    const cacheKey = 'syncThrowLeakKey'
+
+    cache({ cacheKey, getValue: () => 'original data' })
+
+    // The item is now stale.
+    t.mock.timers.tick(100)
+
+    const expectedError = new Error('Synchronous crash')
+    expect(() => cache({ cacheKey, getValue: () => { throw expectedError } }))
+      .toThrow(expectedError)
+
+    t.mock.timers.tick(401)
+
+    const result3 = cache({ cacheKey, getValue: () => 'fresh data' })
+
+    expect(result3).toBe('fresh data')
+  })
+
+  it('returns stale data instead of a pending promise for concurrent requests during a background refresh', async t => {
+    t.mock.timers.enable()
+
+    const cache = createCache({ allowReturnExpiredValue: true, expirationTime: 50 })
+    const cacheKey = 'concurrentRefreshKey'
+
+    cache({ cacheKey, getValue: () => 'original data' })
+
+    // 2. Fast-forward to 100ms. The item is now stale.
+    t.mock.timers.tick(100)
+
+    /** @type {(value: any) => void} */
+    let resolvePromise
+    const pendingPromise = new Promise((resolve) => { resolvePromise = resolve })
+    const result2 = cache({ cacheKey, getValue: () => pendingPromise })
+
+    expect(result2).toBe('original data')
+
+    t.mock.timers.tick(10)
+
+    const result3 = cache({ cacheKey, getValue: () => 'should not be called' })
+
+    expect(result3).toBe('original data')
+
+    // Cleanup: resolve the promise so it doesn't hang the test runner
+    // @ts-ignore
+    resolvePromise('new data')
+    await pendingPromise
+  })
+
+  it('returns a stale result while a background promise is pending, then returns the fresh result once resolved', async t => {
+    t.mock.timers.enable()
+
+    const cache = createCache({ allowReturnExpiredValue: true, expirationTime: 50 })
+    const cacheKey = 'staleWhilePendingKey'
+
+    const initialPromise = Promise.resolve('original data')
+    await cache({ cacheKey, getValue: () => initialPromise })
+
+    t.mock.timers.tick(100)
+
+    /** @type {(value: any) => void} */
+    let resolvePromise
+    const pendingPromise = new Promise(resolve => { resolvePromise = resolve })
+
+    const refreshResult = cache({ cacheKey, getValue: () => pendingPromise })
+    expect(await refreshResult).toBe('original data')
+
+    t.mock.timers.tick(10)
+
+    const concurrentResult = cache({ cacheKey, getValue: () => 'should not be called' })
+    expect(await concurrentResult).toBe('original data')
+
+    // @ts-ignore
+    resolvePromise('fresh data')
+    await pendingPromise
+
+    const finalResult = cache({ cacheKey, getValue: () => 'should not be called either' })
+    expect(await finalResult).toBe('fresh data')
   })
 })
 
@@ -183,6 +430,18 @@ export function expect(actual) {
 
       const actualCount = actual.mock.callCount()
       assert.strictEqual(actualCount, count, `Expected mock function to be called ${count} times, but was called ${actualCount} times.`)
+    },
+
+    /** @arg {*} expected */
+    toThrow(expected) {
+      let didThrow = false
+      try {
+        actual()
+      } catch (e) {
+        didThrow = true
+        assert.strictEqual(e, expected)
+      }
+      assert.ok(didThrow, 'Expected function to throw, it did not.')
     },
 
     rejects: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "checkJs": true,
     "noEmit": true,
     "strict": true,
+    "lib": ["ES2024"],
     "useUnknownInCatchVariables": false,
     "esModuleInterop": true,
     "allowImportingTsExtensions": true


### PR DESCRIPTION
Now removes item from the cache at a certain time to prevent extreme memory build-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cache expiration, background refresh, and automatic cleanup behavior

* **Bug Fixes**
  * Safer promise handling and changed rejection behavior for cached values to avoid propagating failures
  * Improved memory-leak protection in cache logic

* **Breaking Changes**
  * Public cache type signature updated (removes previous catchable value allowance)

* **Chores**
  * TS config updated to ES2024
  * Expanded test suite for memory, timers, and concurrency
  * Lint rule adjusted and test script updated to expose GC during tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->